### PR TITLE
Update README to clarify direct CLI usage of MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ qwen --prompt "Add a movie called 'Pulp Fiction' released in 1994, directed by Q
 
 Note: The `--yolo` flag automatically accepts tool execution without confirmation. For interactive use, you can run `qwen` without flags and ask questions naturally.
 
-Note: The `--yolo` flag automatically accepts tool execution without confirmation. For interactive use, you can run `qwen` without flags and ask questions naturally.
+**Direct CLI Usage**: You can run these commands directly in any terminal window while in the repository root directory - no need to go through Qwen Code for simple operations!
 
 ### Data Persistence
 


### PR DESCRIPTION
Added a note that users can run MCP tool commands directly in terminal windows while in the repo root directory, without needing to go through Qwen Code for simple operations.